### PR TITLE
Add overrideIp sniffing option

### DIFF
--- a/app/dispatcher/default.go
+++ b/app/dispatcher/default.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/xtls/xray-core/common"
 	"github.com/xtls/xray-core/common/buf"
+	"github.com/xtls/xray-core/common/dice"
 	"github.com/xtls/xray-core/common/errors"
 	"github.com/xtls/xray-core/common/log"
 	"github.com/xtls/xray-core/common/net"
@@ -290,6 +291,19 @@ func (d *DefaultDispatcher) Dispatch(ctx context.Context, destination net.Destin
 				}
 				if sniffingRequest.RouteOnly && protocol != "fakedns" && protocol != "fakedns+others" && !isFakeIP {
 					ob.RouteTarget = destination
+					if sniffingRequest.OverrideIp && !ob.OriginalTarget.Address.Family().IsDomain() {
+						ips, err := d.dns.LookupIP(domain, dns.IPOption{
+							IPv4Enable: ob.OriginalTarget.Address.Family().IsIPv4(),
+							IPv6Enable: ob.OriginalTarget.Address.Family().IsIPv6(),
+							FakeEnable: false,
+						})
+						if len(ips) == 0 || err != nil {
+							errors.LogWarning(ctx, "failed to resolve domain:", domain, ", Falling back to client-requested IP:", destination.Address.String())
+						} else {
+							destination.Address = net.IPAddress(ips[dice.Roll(len(ips))])
+							ob.Target = destination
+						}
+					}
 				} else {
 					ob.Target = destination
 				}
@@ -344,6 +358,19 @@ func (d *DefaultDispatcher) DispatchLink(ctx context.Context, destination net.De
 			}
 			if sniffingRequest.RouteOnly && protocol != "fakedns" && protocol != "fakedns+others" && !isFakeIP {
 				ob.RouteTarget = destination
+				if sniffingRequest.OverrideIp && !ob.OriginalTarget.Address.Family().IsDomain() {
+					ips, err := d.dns.LookupIP(domain, dns.IPOption{
+						IPv4Enable: ob.OriginalTarget.Address.Family().IsIPv4(),
+						IPv6Enable: ob.OriginalTarget.Address.Family().IsIPv6(),
+						FakeEnable: false,
+					})
+					if len(ips) == 0 || err != nil {
+						errors.LogWarning(ctx, "failed to resolve domain:", domain, ", Falling back to client-requested IP:", destination.Address.String())
+					} else {
+						destination.Address = net.IPAddress(ips[dice.Roll(len(ips))])
+						ob.Target = destination
+					}
+				}
 			} else {
 				ob.Target = destination
 			}

--- a/app/proxyman/config.pb.go
+++ b/app/proxyman/config.pb.go
@@ -192,6 +192,7 @@ type SniffingConfig struct {
 	// message.
 	MetadataOnly bool `protobuf:"varint,4,opt,name=metadata_only,json=metadataOnly,proto3" json:"metadata_only,omitempty"`
 	RouteOnly    bool `protobuf:"varint,5,opt,name=route_only,json=routeOnly,proto3" json:"route_only,omitempty"`
+	OverrideIp   bool `protobuf:"varint,6,opt,name=override_ip,json=overrideIp,proto3" json:"override_ip,omitempty"`
 }
 
 func (x *SniffingConfig) Reset() {
@@ -255,6 +256,13 @@ func (x *SniffingConfig) GetMetadataOnly() bool {
 func (x *SniffingConfig) GetRouteOnly() bool {
 	if x != nil {
 		return x.RouteOnly
+	}
+	return false
+}
+
+func (x *SniffingConfig) GetOverrideIp() bool {
+	if x != nil {
+		return x.OverrideIp
 	}
 	return false
 }

--- a/app/proxyman/config.proto
+++ b/app/proxyman/config.proto
@@ -55,6 +55,7 @@ message SniffingConfig {
   bool metadata_only = 4;
 
   bool route_only = 5;
+  bool override_ip = 6;
 }
 
 message ReceiverConfig {

--- a/app/proxyman/inbound/worker.go
+++ b/app/proxyman/inbound/worker.go
@@ -104,6 +104,7 @@ func (w *tcpWorker) callback(conn stat.Connection) {
 		content.SniffingRequest.ExcludeForDomain = w.sniffingConfig.DomainsExcluded
 		content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
 		content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
+		content.SniffingRequest.OverrideIp = w.sniffingConfig.OverrideIp
 	}
 	ctx = session.ContextWithContent(ctx, content)
 
@@ -327,6 +328,7 @@ func (w *udpWorker) callback(b *buf.Buffer, source net.Destination, originalDest
 				content.SniffingRequest.OverrideDestinationForProtocol = w.sniffingConfig.DestinationOverride
 				content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
 				content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
+				content.SniffingRequest.OverrideIp = w.sniffingConfig.OverrideIp
 			}
 			ctx = session.ContextWithContent(ctx, content)
 			if err := w.proxy.Process(ctx, net.Network_UDP, conn, w.dispatcher); err != nil {
@@ -489,6 +491,7 @@ func (w *dsWorker) callback(conn stat.Connection) {
 		content.SniffingRequest.ExcludeForDomain = w.sniffingConfig.DomainsExcluded
 		content.SniffingRequest.MetadataOnly = w.sniffingConfig.MetadataOnly
 		content.SniffingRequest.RouteOnly = w.sniffingConfig.RouteOnly
+		content.SniffingRequest.OverrideIp = w.sniffingConfig.OverrideIp
 	}
 	ctx = session.ContextWithContent(ctx, content)
 

--- a/common/session/session.go
+++ b/common/session/session.go
@@ -80,6 +80,7 @@ type SniffingRequest struct {
 	Enabled                        bool
 	MetadataOnly                   bool
 	RouteOnly                      bool
+	OverrideIp                     bool
 }
 
 // Content is the metadata of the connection content.

--- a/infra/conf/xray.go
+++ b/infra/conf/xray.go
@@ -55,6 +55,7 @@ type SniffingConfig struct {
 	DomainsExcluded *StringList `json:"domainsExcluded"`
 	MetadataOnly    bool        `json:"metadataOnly"`
 	RouteOnly       bool        `json:"routeOnly"`
+	OverrideIp      bool        `json:"overrideIp"`
 }
 
 // Build implements Buildable.
@@ -92,6 +93,7 @@ func (c *SniffingConfig) Build() (*proxyman.SniffingConfig, error) {
 		DomainsExcluded:     d,
 		MetadataOnly:        c.MetadataOnly,
 		RouteOnly:           c.RouteOnly,
+		OverrideIp:          c.OverrideIp,
 	}, nil
 }
 


### PR DESCRIPTION
If the original request is an IP address instead of a domain name, the built-in DNS will be immediately invoked to resolve the sniffed domain, and the IP in the original request will be replaced accordingly.

This option is only effective when routeOnly is set to true.

This feature addresses the issue where Xray acts as a gateway using transparent proxy, with routeOnly enabled to prevent remote Xray instances from performing secondary DNS resolution. In such scenarios, client-side DNS may be polluted due to DoH (DNS over HTTPS). Previously, it was necessary to block all known DoH servers as much as possible. Now, simply enabling this option resolves the problem.